### PR TITLE
Network API refinements for more flexibility and clarity

### DIFF
--- a/NetworkingTests/Resource/ResourceTests.swift
+++ b/NetworkingTests/Resource/ResourceTests.swift
@@ -2,10 +2,10 @@ import XCTest
 @testable import Networking
 
 final class ResourceTests: XCTestCase {
-    private let emptyDecoding = ResourceDecodingExecution.background(EmptyDecoder())
+    private let emptyDecoding = EmptyDecoder()
 
     func testURLRequestFromResourceNoScheme() throws {
-        let resource = Resource<Empty, Empty>(endpoint: "/path/to/resource", decoding: emptyDecoding)
+        let resource = Resource<Empty, Empty>(endpoint: "/path/to/resource", decoder: emptyDecoding)
         let request = try URLRequest(resource: resource,
                                      requestBehavior: EmptyRequestBehavior(),
                                      baseURL: URL(string: "www.karmarama.com")!)
@@ -17,7 +17,7 @@ final class ResourceTests: XCTestCase {
     }
 
     func testURLRequestFromResourceWithScheme() throws {
-        let resource = Resource<Empty, Empty>(endpoint: "/path/to/resource", decoding: emptyDecoding)
+        let resource = Resource<Empty, Empty>(endpoint: "/path/to/resource", decoder: emptyDecoding)
         let request = try URLRequest(resource: resource,
                                      requestBehavior: EmptyRequestBehavior(),
                                      baseURL: URL(string: "https://www.karmarama.com")!)
@@ -31,7 +31,7 @@ final class ResourceTests: XCTestCase {
     func testURLRequestFromResourceWithQuery() throws {
         let resource = Resource<Empty, Empty>(endpoint: "/path/to/resource",
                                               queryParameters: [URLQueryItem(name: "testKey", value: "testValue")],
-                                              decoding: emptyDecoding)
+                                              decoder: emptyDecoding)
 
         let request = try URLRequest(resource: resource,
                                      requestBehavior: EmptyRequestBehavior(),
@@ -48,7 +48,7 @@ final class ResourceTests: XCTestCase {
                                                          method: .post,
                                                          body: HTTP.Body(data: ["Test": "Test"],
                                                                          contentType: JSONContentType()),
-                                                         decoding: emptyDecoding)
+                                                         decoder: emptyDecoding)
 
         let request = try URLRequest(resource: resource,
                                      requestBehavior: EmptyRequestBehavior(),
@@ -61,7 +61,7 @@ final class ResourceTests: XCTestCase {
     }
 
     func testURLRequestFromResourceMalformedResourceError() {
-        let resource = Resource<Empty, Empty>(endpoint: "path/to/resource", decoding: emptyDecoding)
+        let resource = Resource<Empty, Empty>(endpoint: "path/to/resource", decoder: emptyDecoding)
 
         let expect = expectation(description: "Wait for error")
 
@@ -75,7 +75,7 @@ final class ResourceTests: XCTestCase {
     }
 
     func testURLRequestFromResourceMalformedURLError() {
-        let resource = Resource<Empty, Empty>(endpoint: "path/to/resource", decoding: emptyDecoding)
+        let resource = Resource<Empty, Empty>(endpoint: "path/to/resource", decoder: emptyDecoding)
 
         let expect = expectation(description: "Wait for error")
 

--- a/NetworkingTests/Resource/ResourceTests.swift
+++ b/NetworkingTests/Resource/ResourceTests.swift
@@ -2,10 +2,10 @@ import XCTest
 @testable import Networking
 
 final class ResourceTests: XCTestCase {
-    private let emptyDecoding = EmptyDecoder()
+    private let emptyDecoder = EmptyDecoder()
 
     func testURLRequestFromResourceNoScheme() throws {
-        let resource = Resource<Empty, Empty>(endpoint: "/path/to/resource", decoder: emptyDecoding)
+        let resource = Resource<Empty, Empty>(endpoint: "/path/to/resource", decoder: emptyDecoder)
         let request = try URLRequest(resource: resource,
                                      requestBehavior: EmptyRequestBehavior(),
                                      baseURL: URL(string: "www.karmarama.com")!)
@@ -17,7 +17,7 @@ final class ResourceTests: XCTestCase {
     }
 
     func testURLRequestFromResourceWithScheme() throws {
-        let resource = Resource<Empty, Empty>(endpoint: "/path/to/resource", decoder: emptyDecoding)
+        let resource = Resource<Empty, Empty>(endpoint: "/path/to/resource", decoder: emptyDecoder)
         let request = try URLRequest(resource: resource,
                                      requestBehavior: EmptyRequestBehavior(),
                                      baseURL: URL(string: "https://www.karmarama.com")!)
@@ -31,7 +31,7 @@ final class ResourceTests: XCTestCase {
     func testURLRequestFromResourceWithQuery() throws {
         let resource = Resource<Empty, Empty>(endpoint: "/path/to/resource",
                                               queryParameters: [URLQueryItem(name: "testKey", value: "testValue")],
-                                              decoder: emptyDecoding)
+                                              decoder: emptyDecoder)
 
         let request = try URLRequest(resource: resource,
                                      requestBehavior: EmptyRequestBehavior(),
@@ -48,7 +48,7 @@ final class ResourceTests: XCTestCase {
                                                          method: .post,
                                                          body: HTTP.Body(data: ["Test": "Test"],
                                                                          contentType: JSONContentType()),
-                                                         decoder: emptyDecoding)
+                                                         decoder: emptyDecoder)
 
         let request = try URLRequest(resource: resource,
                                      requestBehavior: EmptyRequestBehavior(),
@@ -61,7 +61,7 @@ final class ResourceTests: XCTestCase {
     }
 
     func testURLRequestFromResourceMalformedResourceError() {
-        let resource = Resource<Empty, Empty>(endpoint: "path/to/resource", decoder: emptyDecoding)
+        let resource = Resource<Empty, Empty>(endpoint: "path/to/resource", decoder: emptyDecoder)
 
         let expect = expectation(description: "Wait for error")
 
@@ -75,7 +75,7 @@ final class ResourceTests: XCTestCase {
     }
 
     func testURLRequestFromResourceMalformedURLError() {
-        let resource = Resource<Empty, Empty>(endpoint: "path/to/resource", decoder: emptyDecoding)
+        let resource = Resource<Empty, Empty>(endpoint: "path/to/resource", decoder: emptyDecoder)
 
         let expect = expectation(description: "Wait for error")
 

--- a/NetworkingTests/Webservice/Requests/RequestBehaviorTests.swift
+++ b/NetworkingTests/Webservice/Requests/RequestBehaviorTests.swift
@@ -2,11 +2,11 @@ import XCTest
 @testable import Networking
 
 class RequestBehaviorSimpleTests: XCTestCase {
-    let emptyDecoding = ResourceDecodingExecution.background(EmptyDecoder())
+    let emptyDecoding = EmptyDecoder()
 
     // MARK: - Modify URL components
     func testModifyURLComponentsCalled() throws {
-        let resource = Resource<Empty, Empty>(endpoint: "/", decoding: emptyDecoding)
+        let resource = Resource<Empty, Empty>(endpoint: "/", decoder: emptyDecoding)
         let requestBehaviorMock = RequestBehaviorMock()
 
         _ = try URLRequest(resource: resource,
@@ -17,7 +17,7 @@ class RequestBehaviorSimpleTests: XCTestCase {
     }
 
     func testModifyURLComponentsCalledNested() throws {
-        let resource = Resource<Empty, Empty>(endpoint: "/", decoding: emptyDecoding)
+        let resource = Resource<Empty, Empty>(endpoint: "/", decoder: emptyDecoding)
         let firstRequestBehaviorMock = RequestBehaviorMock()
         let secondRequestBehaviorMock = RequestBehaviorMock()
         let nestedRequestBehaviorMock = firstRequestBehaviorMock.and(secondRequestBehaviorMock)
@@ -31,7 +31,7 @@ class RequestBehaviorSimpleTests: XCTestCase {
     }
 
     func testModifyURLComponentsNestedPayload() throws {
-        let resource = Resource<Empty, Empty>(endpoint: "", decoding: emptyDecoding)
+        let resource = Resource<Empty, Empty>(endpoint: "", decoder: emptyDecoding)
         let firstRequestBehaviorMock = ModifyURLComponentsRequestBehaviorMock()
         firstRequestBehaviorMock.urlComponents = URLComponents(string: "https://a.b.c/path")
         let secondRequestBehaviorMock = ModifyURLComponentsRequestBehaviorMock()
@@ -49,7 +49,7 @@ class RequestBehaviorSimpleTests: XCTestCase {
 }
 
 final class RequestBehaviorTests: XCTestCase {
-    let emptyDecoding = ResourceDecodingExecution.background(EmptyDecoder())
+    let emptyDecoding = EmptyDecoder()
     let sessionMock = URLSessionDataTaskLoaderFake(data: nil,
                                                    response: HTTPURLResponse(url: URL.fake(),
                                                                              statusCode: 200,
@@ -74,7 +74,7 @@ extension RequestBehaviorTests {
                                     session: sessionMock,
                                     defaultRequestBehavior: requestBehaviorMock)
 
-        let resource = Resource<Empty, Empty>(endpoint: "/", decoding: emptyDecoding)
+        let resource = Resource<Empty, Empty>(endpoint: "/", decoder: emptyDecoding)
 
         webservice.load(resource) { _ in
             self.expect.fulfill()
@@ -97,7 +97,7 @@ extension RequestBehaviorTests {
 
         let resource = Resource<Empty, Empty>(endpoint: "/",
                                               requestBehavior: thirdRequestBehaviorMock,
-                                              decoding: emptyDecoding)
+                                              decoder: emptyDecoding)
 
         webservice.load(resource) { _ in
             self.expect.fulfill()
@@ -126,7 +126,7 @@ extension RequestBehaviorTests {
 
         let resource = Resource<Empty, Empty>(endpoint: "/",
                                               requestBehavior: thirdRequestBehaviorMock,
-                                              decoding: emptyDecoding)
+                                              decoder: emptyDecoding)
 
         webservice.load(resource) { _ in
             self.expect.fulfill()
@@ -150,7 +150,7 @@ extension RequestBehaviorTests {
                                     session: sessionMock,
                                     defaultRequestBehavior: requestBehaviorMock)
 
-        let resource = Resource<Empty, Empty>(endpoint: "/", decoding: emptyDecoding)
+        let resource = Resource<Empty, Empty>(endpoint: "/", decoder: emptyDecoding)
 
         webservice.load(resource) { _ in
             self.expect.fulfill()
@@ -173,7 +173,7 @@ extension RequestBehaviorTests {
 
         let resource = Resource<Empty, Empty>(endpoint: "/",
                                               requestBehavior: thirdRequestBehaviorMock,
-                                              decoding: emptyDecoding)
+                                              decoder: emptyDecoding)
 
         webservice.load(resource) { _ in
             self.expect.fulfill()
@@ -196,7 +196,7 @@ extension RequestBehaviorTests {
                                     session: sessionMock,
                                     defaultRequestBehavior: requestBehaviorMock)
 
-        let resource = Resource<Empty, Empty>(endpoint: "/", decoding: emptyDecoding)
+        let resource = Resource<Empty, Empty>(endpoint: "/", decoder: emptyDecoding)
 
         webservice.load(resource) { _ in
             self.expect.fulfill()
@@ -219,7 +219,7 @@ extension RequestBehaviorTests {
 
         let resource = Resource<Empty, Empty>(endpoint: "/",
                                               requestBehavior: thirdRequestBehaviorMock,
-                                              decoding: emptyDecoding)
+                                              decoder: emptyDecoding)
 
         webservice.load(resource) { _ in
             self.expect.fulfill()
@@ -261,7 +261,7 @@ extension RequestBehaviorTests {
 
         let resource = Resource<Empty, Empty>(endpoint: "/",
                                               requestBehavior: thirdRequestBehaviorMock,
-                                              decoding: .background(decoder))
+                                              decoder: decoder)
 
         var data: Data?
         var response: URLResponse?
@@ -317,7 +317,7 @@ extension RequestBehaviorTests {
 
         let resource = Resource<Empty, Empty>(endpoint: "/",
                                               requestBehavior: thirdRequestBehaviorMock,
-                                              decoding: .background(decoder))
+                                              decoder: decoder)
 
         var error: Error! = nil
 
@@ -333,7 +333,7 @@ extension RequestBehaviorTests {
 
         waitForExpectations(timeout: 0.5, handler: nil)
 
-        guard case let Webservice.Error.http(httpCode, httpUnderlying) = error! else {
+        guard case let Webservice.Error.http(httpCode, httpUnderlying, _) = error! else {
             XCTFail("Expected a webservice http error")
             return
         }
@@ -360,7 +360,7 @@ extension RequestBehaviorTests {
                                     session: sessionMock,
                                     defaultRequestBehavior: requestBehaviorMock)
 
-        let resource = Resource<Empty, Empty>(endpoint: "/", decoding: emptyDecoding)
+        let resource = Resource<Empty, Empty>(endpoint: "/", decoder: emptyDecoding)
 
         webservice.load(resource) { _ in
             self.expect.fulfill()
@@ -383,7 +383,7 @@ extension RequestBehaviorTests {
 
         let resource = Resource<Empty, Empty>(endpoint: "/",
                                               requestBehavior: thirdRequestBehaviorMock,
-                                              decoding: emptyDecoding)
+                                              decoder: emptyDecoding)
 
         webservice.load(resource) { _ in
             self.expect.fulfill()

--- a/NetworkingTests/Webservice/Requests/RequestBehaviorTests.swift
+++ b/NetworkingTests/Webservice/Requests/RequestBehaviorTests.swift
@@ -2,11 +2,11 @@ import XCTest
 @testable import Networking
 
 class RequestBehaviorSimpleTests: XCTestCase {
-    let emptyDecoding = EmptyDecoder()
+    let emptyDecoder = EmptyDecoder()
 
     // MARK: - Modify URL components
     func testModifyURLComponentsCalled() throws {
-        let resource = Resource<Empty, Empty>(endpoint: "/", decoder: emptyDecoding)
+        let resource = Resource<Empty, Empty>(endpoint: "/", decoder: emptyDecoder)
         let requestBehaviorMock = RequestBehaviorMock()
 
         _ = try URLRequest(resource: resource,
@@ -17,7 +17,7 @@ class RequestBehaviorSimpleTests: XCTestCase {
     }
 
     func testModifyURLComponentsCalledNested() throws {
-        let resource = Resource<Empty, Empty>(endpoint: "/", decoder: emptyDecoding)
+        let resource = Resource<Empty, Empty>(endpoint: "/", decoder: emptyDecoder)
         let firstRequestBehaviorMock = RequestBehaviorMock()
         let secondRequestBehaviorMock = RequestBehaviorMock()
         let nestedRequestBehaviorMock = firstRequestBehaviorMock.and(secondRequestBehaviorMock)
@@ -31,7 +31,7 @@ class RequestBehaviorSimpleTests: XCTestCase {
     }
 
     func testModifyURLComponentsNestedPayload() throws {
-        let resource = Resource<Empty, Empty>(endpoint: "", decoder: emptyDecoding)
+        let resource = Resource<Empty, Empty>(endpoint: "", decoder: emptyDecoder)
         let firstRequestBehaviorMock = ModifyURLComponentsRequestBehaviorMock()
         firstRequestBehaviorMock.urlComponents = URLComponents(string: "https://a.b.c/path")
         let secondRequestBehaviorMock = ModifyURLComponentsRequestBehaviorMock()
@@ -49,7 +49,7 @@ class RequestBehaviorSimpleTests: XCTestCase {
 }
 
 final class RequestBehaviorTests: XCTestCase {
-    let emptyDecoding = EmptyDecoder()
+    let emptyDecoder = EmptyDecoder()
     let sessionMock = URLSessionDataTaskLoaderFake(data: nil,
                                                    response: HTTPURLResponse(url: URL.fake(),
                                                                              statusCode: 200,
@@ -74,7 +74,7 @@ extension RequestBehaviorTests {
                                     session: sessionMock,
                                     defaultRequestBehavior: requestBehaviorMock)
 
-        let resource = Resource<Empty, Empty>(endpoint: "/", decoder: emptyDecoding)
+        let resource = Resource<Empty, Empty>(endpoint: "/", decoder: emptyDecoder)
 
         webservice.load(resource) { _ in
             self.expect.fulfill()
@@ -97,7 +97,7 @@ extension RequestBehaviorTests {
 
         let resource = Resource<Empty, Empty>(endpoint: "/",
                                               requestBehavior: thirdRequestBehaviorMock,
-                                              decoder: emptyDecoding)
+                                              decoder: emptyDecoder)
 
         webservice.load(resource) { _ in
             self.expect.fulfill()
@@ -126,7 +126,7 @@ extension RequestBehaviorTests {
 
         let resource = Resource<Empty, Empty>(endpoint: "/",
                                               requestBehavior: thirdRequestBehaviorMock,
-                                              decoder: emptyDecoding)
+                                              decoder: emptyDecoder)
 
         webservice.load(resource) { _ in
             self.expect.fulfill()
@@ -150,7 +150,7 @@ extension RequestBehaviorTests {
                                     session: sessionMock,
                                     defaultRequestBehavior: requestBehaviorMock)
 
-        let resource = Resource<Empty, Empty>(endpoint: "/", decoder: emptyDecoding)
+        let resource = Resource<Empty, Empty>(endpoint: "/", decoder: emptyDecoder)
 
         webservice.load(resource) { _ in
             self.expect.fulfill()
@@ -173,7 +173,7 @@ extension RequestBehaviorTests {
 
         let resource = Resource<Empty, Empty>(endpoint: "/",
                                               requestBehavior: thirdRequestBehaviorMock,
-                                              decoder: emptyDecoding)
+                                              decoder: emptyDecoder)
 
         webservice.load(resource) { _ in
             self.expect.fulfill()
@@ -196,7 +196,7 @@ extension RequestBehaviorTests {
                                     session: sessionMock,
                                     defaultRequestBehavior: requestBehaviorMock)
 
-        let resource = Resource<Empty, Empty>(endpoint: "/", decoder: emptyDecoding)
+        let resource = Resource<Empty, Empty>(endpoint: "/", decoder: emptyDecoder)
 
         webservice.load(resource) { _ in
             self.expect.fulfill()
@@ -219,7 +219,7 @@ extension RequestBehaviorTests {
 
         let resource = Resource<Empty, Empty>(endpoint: "/",
                                               requestBehavior: thirdRequestBehaviorMock,
-                                              decoder: emptyDecoding)
+                                              decoder: emptyDecoder)
 
         webservice.load(resource) { _ in
             self.expect.fulfill()
@@ -360,7 +360,7 @@ extension RequestBehaviorTests {
                                     session: sessionMock,
                                     defaultRequestBehavior: requestBehaviorMock)
 
-        let resource = Resource<Empty, Empty>(endpoint: "/", decoder: emptyDecoding)
+        let resource = Resource<Empty, Empty>(endpoint: "/", decoder: emptyDecoder)
 
         webservice.load(resource) { _ in
             self.expect.fulfill()
@@ -383,7 +383,7 @@ extension RequestBehaviorTests {
 
         let resource = Resource<Empty, Empty>(endpoint: "/",
                                               requestBehavior: thirdRequestBehaviorMock,
-                                              decoder: emptyDecoding)
+                                              decoder: emptyDecoder)
 
         webservice.load(resource) { _ in
             self.expect.fulfill()

--- a/NetworkingTests/Webservice/WebserviceTests.swift
+++ b/NetworkingTests/Webservice/WebserviceTests.swift
@@ -4,7 +4,7 @@ import XCTest
 final class WebserviceTests: XCTestCase {
     private var webservice: ResourceRequestable!
 
-    private let emptyDecoding = EmptyDecoder()
+    private let emptyDecoder = EmptyDecoder()
 
     func testEmptyDataTaskSuccess() {
         let sessionMock = URLSessionDataTaskLoaderFake(data: nil,
@@ -16,7 +16,7 @@ final class WebserviceTests: XCTestCase {
 
         webservice = Webservice(baseURL: URL.fake(), session: sessionMock)
 
-        let resource = Resource<Empty, Empty>(endpoint: "/", decoder: emptyDecoding)
+        let resource = Resource<Empty, Empty>(endpoint: "/", decoder: emptyDecoder)
 
         let expect = expectation(description: "async")
 
@@ -40,7 +40,7 @@ final class WebserviceTests: XCTestCase {
 
         webservice = Webservice(baseURL: URL.fake(), session: sessionMock)
 
-        let resource = Resource<Empty, Empty>(endpoint: "/", decoder: emptyDecoding)
+        let resource = Resource<Empty, Empty>(endpoint: "/", decoder: emptyDecoder)
 
         let expect = expectation(description: "async")
 
@@ -72,7 +72,7 @@ final class WebserviceTests: XCTestCase {
 
         webservice = Webservice(baseURL: URL.fake(), session: sessionMock)
 
-        let resource = Resource<Empty, Empty>(endpoint: "/", decoder: emptyDecoding)
+        let resource = Resource<Empty, Empty>(endpoint: "/", decoder: emptyDecoder)
 
         let expect = expectation(description: "async")
 
@@ -106,7 +106,7 @@ final class WebserviceTests: XCTestCase {
                                 session: sessionMock,
                                 defaultRequestBehavior: requestBehaviorMock)
 
-        let resource = Resource<Empty, Empty>(endpoint: "/", decoder: emptyDecoding)
+        let resource = Resource<Empty, Empty>(endpoint: "/", decoder: emptyDecoder)
 
         let expect = expectation(description: "async")
 
@@ -137,7 +137,7 @@ final class WebserviceTests: XCTestCase {
                                 session: sessionMock,
                                 defaultRequestBehavior: requestBehaviorMock)
 
-        let resource = Resource<Empty, Empty>(endpoint: "/", decoder: emptyDecoding)
+        let resource = Resource<Empty, Empty>(endpoint: "/", decoder: emptyDecoder)
 
         let expect = expectation(description: "async")
 
@@ -169,7 +169,7 @@ final class WebserviceTests: XCTestCase {
                                 session: sessionMock,
                                 defaultRequestBehavior: requestBehaviorMock)
 
-        let resource = Resource<Empty, Empty>(endpoint: "/", decoder: emptyDecoding)
+        let resource = Resource<Empty, Empty>(endpoint: "/", decoder: emptyDecoder)
 
         let expect = expectation(description: "async")
 
@@ -205,7 +205,7 @@ extension WebserviceTests {
 
         let resource = Resource<Empty, Empty>(endpoint: "/",
                                               requestBehavior: validationBehavior,
-                                              decoder: emptyDecoding)
+                                              decoder: emptyDecoder)
 
         let expectAsync = expectation(description: "async")
         let expectBackground = expectation(description: "background")
@@ -239,7 +239,7 @@ extension WebserviceTests {
 
         let resource = Resource<Empty, Empty>(endpoint: "/",
                                               requestBehavior: validationBehavior,
-                                              decoder: emptyDecoding)
+                                              decoder: emptyDecoder)
 
         let expectAsync = expectation(description: "async")
         let expectBackground = expectation(description: "background")
@@ -272,7 +272,7 @@ extension WebserviceTests {
 
         let resource = Resource<Empty, Empty>(endpoint: "/",
                                               requestBehavior: validationBehavior,
-                                              decoder: emptyDecoding)
+                                              decoder: emptyDecoder)
 
         let expectAsync = expectation(description: "async")
         let expectBackground = expectation(description: "background")
@@ -306,7 +306,7 @@ extension WebserviceTests {
 
         let resource = Resource<Empty, Empty>(endpoint: "/",
                                               requestBehavior: validationBehavior,
-                                              decoder: emptyDecoding)
+                                              decoder: emptyDecoder)
 
         let expectAsync = expectation(description: "async")
         let expectBackground = expectation(description: "background")

--- a/NetworkingTests/Webservice/WebserviceTests.swift
+++ b/NetworkingTests/Webservice/WebserviceTests.swift
@@ -4,7 +4,7 @@ import XCTest
 final class WebserviceTests: XCTestCase {
     private var webservice: ResourceRequestable!
 
-    private let emptyDecoding = ResourceDecodingExecution.background(EmptyDecoder())
+    private let emptyDecoding = EmptyDecoder()
 
     func testEmptyDataTaskSuccess() {
         let sessionMock = URLSessionDataTaskLoaderFake(data: nil,
@@ -16,7 +16,7 @@ final class WebserviceTests: XCTestCase {
 
         webservice = Webservice(baseURL: URL.fake(), session: sessionMock)
 
-        let resource = Resource<Empty, Empty>(endpoint: "/", decoding: emptyDecoding)
+        let resource = Resource<Empty, Empty>(endpoint: "/", decoder: emptyDecoding)
 
         let expect = expectation(description: "async")
 
@@ -40,7 +40,7 @@ final class WebserviceTests: XCTestCase {
 
         webservice = Webservice(baseURL: URL.fake(), session: sessionMock)
 
-        let resource = Resource<Empty, Empty>(endpoint: "/", decoding: emptyDecoding)
+        let resource = Resource<Empty, Empty>(endpoint: "/", decoder: emptyDecoding)
 
         let expect = expectation(description: "async")
 
@@ -49,7 +49,7 @@ final class WebserviceTests: XCTestCase {
             case .success:
                 XCTFail("Expected an HTTP status error")
             case let .failure(error):
-                if case let Webservice.Error.http(code, _) = error {
+                if case let Webservice.Error.http(code, _, _) = error {
                     XCTAssertEqual(code, 400)
                 } else {
                     XCTFail("Expected a Webservice.Error.http error type")
@@ -72,7 +72,7 @@ final class WebserviceTests: XCTestCase {
 
         webservice = Webservice(baseURL: URL.fake(), session: sessionMock)
 
-        let resource = Resource<Empty, Empty>(endpoint: "/", decoding: emptyDecoding)
+        let resource = Resource<Empty, Empty>(endpoint: "/", decoder: emptyDecoding)
 
         let expect = expectation(description: "async")
 
@@ -81,7 +81,7 @@ final class WebserviceTests: XCTestCase {
             case .success:
                 XCTFail("Expected an unknown error")
             case let .failure(error):
-                if case let Webservice.Error.unknown(error as NSError) = error {
+                if case let Webservice.Error.system(error as NSError) = error {
                     XCTAssertEqual(error, placeholderError)
                 } else {
                     XCTFail("Expected a Webservice.Error.http error type")
@@ -106,7 +106,7 @@ final class WebserviceTests: XCTestCase {
                                 session: sessionMock,
                                 defaultRequestBehavior: requestBehaviorMock)
 
-        let resource = Resource<Empty, Empty>(endpoint: "/", decoding: emptyDecoding)
+        let resource = Resource<Empty, Empty>(endpoint: "/", decoder: emptyDecoding)
 
         let expect = expectation(description: "async")
 
@@ -137,7 +137,7 @@ final class WebserviceTests: XCTestCase {
                                 session: sessionMock,
                                 defaultRequestBehavior: requestBehaviorMock)
 
-        let resource = Resource<Empty, Empty>(endpoint: "/", decoding: emptyDecoding)
+        let resource = Resource<Empty, Empty>(endpoint: "/", decoder: emptyDecoding)
 
         let expect = expectation(description: "async")
 
@@ -169,7 +169,7 @@ final class WebserviceTests: XCTestCase {
                                 session: sessionMock,
                                 defaultRequestBehavior: requestBehaviorMock)
 
-        let resource = Resource<Empty, Empty>(endpoint: "/", decoding: emptyDecoding)
+        let resource = Resource<Empty, Empty>(endpoint: "/", decoder: emptyDecoding)
 
         let expect = expectation(description: "async")
 
@@ -205,7 +205,7 @@ extension WebserviceTests {
 
         let resource = Resource<Empty, Empty>(endpoint: "/",
                                               requestBehavior: validationBehavior,
-                                              decoding: emptyDecoding)
+                                              decoder: emptyDecoding)
 
         let expectAsync = expectation(description: "async")
         let expectBackground = expectation(description: "background")
@@ -239,7 +239,7 @@ extension WebserviceTests {
 
         let resource = Resource<Empty, Empty>(endpoint: "/",
                                               requestBehavior: validationBehavior,
-                                              decoding: emptyDecoding)
+                                              decoder: emptyDecoding)
 
         let expectAsync = expectation(description: "async")
         let expectBackground = expectation(description: "background")
@@ -272,7 +272,7 @@ extension WebserviceTests {
 
         let resource = Resource<Empty, Empty>(endpoint: "/",
                                               requestBehavior: validationBehavior,
-                                              decoding: emptyDecoding)
+                                              decoder: emptyDecoding)
 
         let expectAsync = expectation(description: "async")
         let expectBackground = expectation(description: "background")
@@ -306,7 +306,7 @@ extension WebserviceTests {
 
         let resource = Resource<Empty, Empty>(endpoint: "/",
                                               requestBehavior: validationBehavior,
-                                              decoding: emptyDecoding)
+                                              decoder: emptyDecoding)
 
         let expectAsync = expectation(description: "async")
         let expectBackground = expectation(description: "background")
@@ -319,66 +319,6 @@ extension WebserviceTests {
         DispatchQueue(label: "worker").async {
             self.webservice.load(resource, queue: queue) { _ in
                 XCTAssertEqual(OperationQueue.current, queue)
-                expectBackground.fulfill()
-            }
-        }
-
-        waitForExpectations(timeout: 0.5, handler: nil)
-    }
-
-    func testResponseOnMainThreadBackgroundDecoding() {
-        let sessionMock = URLSessionDataTaskLoaderFake(data: nil,
-                                                       response: HTTPURLResponse(url: URL.fake(),
-                                                                                 statusCode: 200,
-                                                                                 httpVersion: nil,
-                                                                                 headerFields: nil),
-                                                       error: nil)
-        let verifiedDecoding = ResourceDecodingExecution.background(BackgroundDecoderValidator())
-
-        webservice = Webservice(baseURL: URL.fake(), session: sessionMock)
-
-        let resource = Resource<Empty, Empty>(endpoint: "/",
-                                              decoding: verifiedDecoding)
-
-        let expectAsync = expectation(description: "async")
-        let expectBackground = expectation(description: "background")
-
-        webservice.load(resource) { _ in
-            expectAsync.fulfill()
-        }
-
-        DispatchQueue(label: "worker").async {
-            self.webservice.load(resource) { _ in
-                expectBackground.fulfill()
-            }
-        }
-
-        waitForExpectations(timeout: 0.5, handler: nil)
-    }
-
-    func testResponseOnMainThreadQualityDecoding() {
-        let sessionMock = URLSessionDataTaskLoaderFake(data: nil,
-                                                       response: HTTPURLResponse(url: URL.fake(),
-                                                                                 statusCode: 200,
-                                                                                 httpVersion: nil,
-                                                                                 headerFields: nil),
-                                                       error: nil)
-        let verifiedDecoding = ResourceDecodingExecution.qos(BackgroundDecoderValidator(), .default)
-
-        webservice = Webservice(baseURL: URL.fake(), session: sessionMock)
-
-        let resource = Resource<Empty, Empty>(endpoint: "/",
-                                              decoding: verifiedDecoding)
-
-        let expectAsync = expectation(description: "async")
-        let expectBackground = expectation(description: "background")
-
-        webservice.load(resource) { _ in
-            expectAsync.fulfill()
-        }
-
-        DispatchQueue(label: "worker").async {
-            self.webservice.load(resource) { _ in
                 expectBackground.fulfill()
             }
         }

--- a/Sources/Resource/Resource.swift
+++ b/Sources/Resource/Resource.swift
@@ -4,30 +4,25 @@ public protocol ResourceDecoder {
     func decode<Value: Decodable>(_ type: Value.Type, from data: Data?, response: HTTPURLResponse) throws -> Value
 }
 
-public enum ResourceDecodingExecution {
-    case background(ResourceDecoder)
-    case qos(ResourceDecoder, DispatchQoS.QoSClass)
-}
-
 public struct Resource<Request: Encodable, Response: Decodable> {
     let endpoint: String
     let queryParameters: [URLQueryItem]
     let method: HTTP.Method
     let body: HTTP.Body<Request>?
     let requestBehavior: RequestBehavior
-    let decoding: ResourceDecodingExecution
+    let decoder: ResourceDecoder
 
     public init(endpoint: String, //swiftlint:disable:this function_default_parameter_at_end
                 queryParameters: [URLQueryItem] = [],
                 method: HTTP.Method = .get,
                 body: HTTP.Body<Request>? = nil,
                 requestBehavior: RequestBehavior? = nil,
-                decoding: ResourceDecodingExecution) {
+                decoder: ResourceDecoder) {
             self.endpoint = endpoint
             self.queryParameters = queryParameters
             self.method = method
             self.body = body
             self.requestBehavior = requestBehavior ?? EmptyRequestBehavior()
-            self.decoding = decoding
+            self.decoder = decoder
     }
 }

--- a/Sources/Webservice/HTTP/Headers/ContentType.swift
+++ b/Sources/Webservice/HTTP/Headers/ContentType.swift
@@ -34,8 +34,8 @@ public struct JSONContentType: ContentType {
     }
 
     private let charSet: CharSet?
-    private let _encoder: JSONEncoder
-    private let _decoder: JSONDecoder
+    public private (set) var encoder: ContentTypeEncoder?
+    public private (set) var decoder: ContentTypeDecoder?
 
     public var header: HTTP.Header {
 
@@ -45,20 +45,12 @@ public struct JSONContentType: ContentType {
         return ("Content-Type", "application/json")
     }
 
-    public var encoder: ContentTypeEncoder? {
-        return _encoder
-    }
-
-    public var decoder: ContentTypeDecoder? {
-        return _decoder
-    }
-
     public init(charSet: CharSet? = nil,
                 encoder: JSONEncoder = JSONEncoder(),
                 decoder: JSONDecoder = JSONDecoder()) {
         self.charSet = charSet
-        self._encoder = encoder
-        self._decoder = decoder
+        self.encoder = encoder
+        self.decoder = decoder
     }
 }
 

--- a/Sources/Webservice/HTTP/Headers/ContentType.swift
+++ b/Sources/Webservice/HTTP/Headers/ContentType.swift
@@ -34,6 +34,9 @@ public struct JSONContentType: ContentType {
     }
 
     private let charSet: CharSet?
+    private let _encoder: JSONEncoder
+    private let _decoder: JSONDecoder
+
     public var header: HTTP.Header {
 
         if let charSet = charSet {
@@ -43,15 +46,19 @@ public struct JSONContentType: ContentType {
     }
 
     public var encoder: ContentTypeEncoder? {
-        return JSONEncoder()
+        return _encoder
     }
 
     public var decoder: ContentTypeDecoder? {
-        return JSONDecoder()
+        return _decoder
     }
 
-    public init(charSet: CharSet? = nil) {
+    public init(charSet: CharSet? = nil,
+                encoder: JSONEncoder = JSONEncoder(),
+                decoder: JSONDecoder = JSONDecoder()) {
         self.charSet = charSet
+        self._encoder = encoder
+        self._decoder = decoder
     }
 }
 


### PR DESCRIPTION
- Exposed the data from an HTTP error response
- Allowed injection of encoder/decoder into the framework provided ContentType
- Removed the convoluted background decoding strategy, solely rely on the queue provided.
- Renamed unknown errors to system errors for clarity.