### PR TITLE
Making the HTTP method always upper case for consistency

### DIFF
--- a/Sources/Extensions/URLRequest+Extension.swift
+++ b/Sources/Extensions/URLRequest+Extension.swift
@@ -40,6 +40,6 @@ extension URLRequest {
             allHTTPHeaderFields = fields
         }
 
-        httpMethod = resource.method.rawValue
+        httpMethod = resource.method.rawValue.uppercased()
     }
 }


### PR DESCRIPTION
Found an issue on a project where "PATCH", a less used HTTP method, was being sent outbound as "patch" and the backend library for parsing request methods is case sensitive. Given iOS automatically changes other methods to upper, forcing all to be upper case by default.